### PR TITLE
Fix error in `make` when `planuml/` and `diagrams/` don't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: clean build
 
 clean:
-	rm plantuml/* diagrams/*
+	rm -f plantuml/* diagrams/*
 
 build:
 	structurizr-cli export -workspace src/workspace.dsl -format plantuml -o plantuml


### PR DESCRIPTION
When running `make` for the first time, the referenced directories don't exist, and the `clean:` task fails with an error.

This PR adds the `-f` flag to `rm` which makes it silently ignore that error, and allows the build to proceed. Also adds a newline at the end.