### PR TITLE
Add docker tasks for non mac envs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,21 @@
+CLI_CMD=structurizr-cli
+
+.PHONY: docker docker-pull
+
 all: clean build
 
 clean:
 	rm -f plantuml/* diagrams/*
 
+docker:
+	$(eval export CLI_CMD=docker run -it --rm -v ${PWD}:/usr/local/structurizr structurizr/cli)
+
+docker-pull:
+	docker pull structurizr/cli:latest
+
 build:
-	structurizr-cli export -workspace src/workspace.dsl -format plantuml -o plantuml
+	${CLI_CMD} export -workspace src/workspace.dsl -format plantuml -o plantuml
 	plantuml plantuml/*.puml -o ${PWD}/diagrams/
 
 push:
-	structurizr-cli push -id ${STRUCTURIZR_WORKSPACE} -key ${STRUCTURIZR_KEY} -secret ${STRUCTURIZR_SECRET} -workspace src/workspace.dsl
+	${CLI_CMD} push -id ${STRUCTURIZR_WORKSPACE} -key ${STRUCTURIZR_KEY} -secret ${STRUCTURIZR_SECRET} -workspace src/workspace.dsl

--- a/Readme.md
+++ b/Readme.md
@@ -1,23 +1,40 @@
 # GOV.UK architecture as code
 
-This project models the services and boundaries of GOV.UK using C4 and Structurizr. 
+This project models the services and boundaries of GOV.UK using C4 and Structurizr.
 
-**Important!** This is a scratch-pad for modelling the organisation as I explore the applications within GOV.UK. It's a tool for my learning, and shouldn't be taken to be accurate!
+**Important!** This is a scratch-pad for exploration and modelling the organisation and applications within GOV.UK. It's a tool for learning, and shouldn't be taken to be accurate or in any way 'official'
 
 # Prerequisites
 
 - PlantUML
-- Structurizr CLI
+- Structurizr CLI (or Docker)
+
+## Mac OSX
 
 ```bash
 brew install structurizr-cli plantuml
 ```
 
+## Ubuntu
+
+The `structurizr-cli` binary is not available on Ubuntu - you'll need to run the provided Docker container instead.
+So you'll need:
+
+- Docker
+
+To download the `structurizr/cli` docker container, run `make docker-pull`
+When running make tasks, use `docker` as the first task in the list, and the `structurizr-cli` commands will be run via the docker container.
+E.g.
+
+Without docker: `make build`
+With docker: `make docker build`
+
+
 # Generating diagrams
 
 - `make`: remove plantuml and diagrams, and generate new ones.
-- `make build`: generate PlantUML output and generate PNG diagrams.
-- `make clean`: remove generated outputfrom from `plantuml/` and `diagrams/`.
+- `make (docker) build`: generate PlantUML output and generate PNG diagrams.
+- `make (docker) clean`: remove generated outputfrom from `plantuml/` and `diagrams/`.
 
 # Pushing diagrams to Structurizr
 


### PR DESCRIPTION
Add make task to enable running structurizr-cli via Docker, plus docs
    
The `structurizr-cli` binary is only available for Mac OSX. To enable users on other platforms, this PR adds two Makefile tasks:
    
1. `docker` - to be prepended to other tasks and allow running via Docker
2. `docker-pull` - to download the latest `structurizr-cli` docker image

Also adds explanatory note for the above to the README, and slightly re-words the disclaimer.

NOTE: includes the commit from #1, so please review/merge that one first